### PR TITLE
feat: expose blob store credential type

### DIFF
--- a/chart/templates/archivista-object-store.yaml
+++ b/chart/templates/archivista-object-store.yaml
@@ -11,3 +11,4 @@ stringData:
   ARCHIVISTA_BLOB_STORE_SECRET_ACCESS_KEY_ID: "{{ .Values.storage.secretKey }}"
   ARCHIVISTA_BLOB_STORE_USE_TLS: "{{ .Values.storage.secure | toString }}"
   ARCHIVISTA_BLOB_STORE_BUCKET_NAME: "{{ .Values.storage.bucket }}"       
+  ARCHIVISTA_BLOB_STORE_CREDENTIAL_TYPE: "{{ .Values.storage.credentialType }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,6 @@
 storage:
   secure: true
+  credentialType: ACCESS_KEY
   accessKey: "###ZARF_VAR_ACCESS_KEY###"
   secretKey: "###ZARF_VAR_SECRET_KEY###"
   bucket: "archivista"


### PR DESCRIPTION
## Description

Adds `storage.credentialType` to the config chart and sets it as `ARCHIVISTA_BLOB_STORE_CREDENTIAL_TYPE` in the blob storage secret

## Related Issue

Fixes #14 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-archivista/blob/main/CONTRIBUTING.md#developer-workflow) followed
