### PR TITLE
chore: add zarf annotations

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -7,6 +7,11 @@ metadata:
   name: archivista
   description: "A deployment of Archivista, an application for storing in-toto attestations."
   version: "dev"
+  annotations:
+    title: Archivista
+    description: Archivista is a graph and storage service for in-toto attestations, enabling the discovery, retrieval, and querying of software artifact attestations. It provides a centralized, trusted store for supply chain metadata, allowing users to store, retrieve, and query relationships between attestations via a GraphQL API. Archivista enhances software supply chain security by creating a queryable graph of metadata while storing signed attestations, supporting policy validation without manual listing of expected attestations. Archivista integrates seamlessly with major cloud service providers and supports various architectures (Darwin, Windows, ARM), making it a versatile solution for securing software supply chains across different environments.
+    categories: Security,Software Dev,IT Management,Databases
+    keywords: Supply Chain Security,Software Attestations,GraphQL API,Cloud Integration,Software Metadata,Policy Validation,In-Toto Attestations,Cross-Platform Support
 
 variables:
   - name: DB_PASSWORD


### PR DESCRIPTION
Add Zarf annotations from security hub.

This PR adds metadata annotations from the security hub repository to the Zarf package configuration.

Changes:
- Add title annotation
- Add description annotation
- Add categories annotation
- Add keywords annotation
- Add tagline annotation (if present)
